### PR TITLE
Convert ComponentEnum into a 'reachable_from' ontology  tied to the Biolink Infores catalog

### DIFF
--- a/src/translator_testing_model/schema/translator_testing_model.yaml
+++ b/src/translator_testing_model/schema/translator_testing_model.yaml
@@ -883,12 +883,13 @@ enums:
       drug-to-gene:
 
   ComponentEnum:
-    permissible_values:
-      arax:
-      aragorn:
-      ars:
-      bte:
-      improving:
+    description: >-
+      Translator components are identified by their InfoRes identifiers.
+    reachable_from:
+      source_ontology: biolink
+      source_nodes:
+        - biolink:infores
+      include_self:  false
 
   #########################
   # TestSuite Model Enums #


### PR DESCRIPTION
The **ComponentEnum** values should be InfoRes CURIE's, with **`reachable_from`** in the **`Enum`** set to point to the Biolink **_infores_** catalog -- and a tiny method added to the **TestCase** generation script to expand the **_infores_** catalog, and validate that the incoming component is a valid **infores** CURIE.

Using **`reachable_from`** means we need to parse and load the _infores-catalog.yaml_ into memory, ensuring ongoing synchronization with **_infores_** catalog updates. 

Since **_infores_** is a purely Translator controlled vocabulary, and lives in the Biolink Model repository, then the **`biolink:infores`** seems reasonable  -- its full URI would be: https://w3id.org/biolink/infores_catalog.yaml.

One concern about the above is that - with respect to Translator testing - we are likely only interested in purely Translator (i.e. TRAPI ARS, ARA and KP) information resource components. Such components are not yet properly annotated as such within the InfoRes catalog. 

Do we need to add an additional (optional) boolean flag slot something like **`translator_infores`**  (or **`translator_component`**, **`translator`** or **`component`**?) into the Biolink Infores catalog schema? Something like:

```yaml

  - id: infores:ncats-ars
    translator: true
```
This would give us a simple filter for pulling out Translator components.

Alternatively, could (or should) we introduce in some hierarchy into the infores file,  perhaps with some 'abstract' groupings, something like:

```yaml
information_resources:
  - id: infores:ncats-translator
    abstract: true

  - id: infores:ncats-ars
    is_a: infores:ncats-translator
...

  - id: infores:ncats-ara
    is_a: infores:ncats-translator
    abstract: true
...

  - id: infores:ncats-kp
    is_a: infores:ncats-translator
    abstract: true
...

  - id: infores:ncats-sri
    is_a: infores:ncats-translator
    abstract: true
...

  - id: infores:arax
    is_a: infores:ncats-ara
...

  - id: infores:molepro
    is_a: infores:ncats-kp
...

  - id: infores:sri-node-normalizer
    is_a: infores:ncats-sri
 ...
```

Perhaps if the above hierarchy  is applied to the infores file, then the ComponentEnum  can be tweaked, something like: 

```yaml
ComponentEnum:
    description: >-
      Translator components are identified by their InfoRes identifiers.
    reachable_from:
      source_ontology: biolink
      source_nodes:
        - biolink.infores:ncats-translator
      include_self:  false
```

(@sierra-moxon please fix the above if I got it wrong... trying to define a kind of **`subproperty of`** relationship rooted by the **`infores:ncats-translator`** identifier).

The merit of this kind of grouping mechanism is fine grained filtering and usage to tag other subsets of infores.
